### PR TITLE
snowflake.core 0.10.0 :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake.core" %}
-{% set version = "0.9.0" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snowflake_core-{{ version }}.tar.gz
-  sha256: 027ba663ca5b797acebd8baaed17b9f885649037d61d40ad3342ad6b2f3d9571
+  sha256: 0ae801138bd893e8b35f78e1475641c63490a1f05a05d0bd370f87a30cd6ccb6
 
 build:
   number: 0


### PR DESCRIPTION
snowflake.core 0.10.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5152]
- dev_url (private): https://pypi.org/project/snowflake.core
- conda-forge: _feedstock not found on conda-forge_
- pypi: https://pypi.org/project/snowflake.core/0.10.0
- pypi inspector: https://inspector.pypi.io/project/snowflake.core/0.10.0

### Explanation of changes:

- bump version
- SF channel already in `abs.yaml` in `main`.


[PKG-5152]: https://anaconda.atlassian.net/browse/PKG-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ